### PR TITLE
token store in sessionStorage instead of localStorage

### DIFF
--- a/frontend/AngularApp/src/app/app.component.ts
+++ b/frontend/AngularApp/src/app/app.component.ts
@@ -25,7 +25,7 @@ export class AppComponent implements OnInit {
   error = this.errorService.error;
 
   ngOnInit() {
-    const token = localStorage.getItem('access_token');
+    const token = sessionStorage.getItem('access_token');
     if (token) {
       this.authService.tokenSignal.set({ access_token: token });
     }
@@ -33,6 +33,6 @@ export class AppComponent implements OnInit {
 
   logoutHandler() {
     this.authService.tokenSignal.set(null);
-    localStorage.removeItem('access_token');
+    sessionStorage.removeItem('access_token');
   }
 }

--- a/frontend/AngularApp/src/app/app.config.ts
+++ b/frontend/AngularApp/src/app/app.config.ts
@@ -13,7 +13,7 @@ const tokenInterceptor = (
   request: HttpRequest<unknown>,
   next: HttpHandlerFn,
 ) => {
-  const token = localStorage.getItem('access_token');
+  const token = sessionStorage.getItem('access_token');
   if (!token) {
     console.log('Request:', request);
     return next(request);

--- a/frontend/AngularApp/src/app/login/login.component.ts
+++ b/frontend/AngularApp/src/app/login/login.component.ts
@@ -35,7 +35,7 @@ export class LoginComponent {
     this.falseCredentials.set(false);
     const subscription = this.userService.login(loginData).subscribe({
       next: (data) => {
-        localStorage.setItem('access_token', data.access_token);
+        sessionStorage.setItem('access_token', data.access_token);
         this.authService.tokenSignal.set(data);
         this.router.navigate(['/profile']);
       },


### PR DESCRIPTION
For Security reason. The JWT is stored in-memory and not accessible by client-side scripts, reducing the risk of XSS attacks.