### PR TITLE
docs(tests): fix gender test description typo

### DIFF
--- a/frontend/AngularApp/src/app/shared/utils/displayUtils.spec.ts
+++ b/frontend/AngularApp/src/app/shared/utils/displayUtils.spec.ts
@@ -112,7 +112,7 @@ describe('DisplayUtils', () => {
         expect(getGender(userWithPossibleMatchesDataType)).toEqual('Female');
       });
 
-      it('should return NOT SPECIFIED when username is not m or f', () => {
+      it('should return NOT SPECIFIED when gender is not m or f', () => {
         userWithPossibleMatchesDataType.gender = 'a';
         expect(getGender(userWithUserDataType)).toEqual('NOT SPECIFIED');
       });


### PR DESCRIPTION
Change "username" to "gender" in displayUtils test description to accurately reflect what the test is verifying. This improves test readability and documentation accuracy.