### PR TITLE
fix(frontend): date wasn't correct

### DIFF
--- a/frontend/AngularApp/src/app/shared/utils/displayUtils.ts
+++ b/frontend/AngularApp/src/app/shared/utils/displayUtils.ts
@@ -68,5 +68,5 @@ export function format24HourDateTime(timestamp: number): string {
     minute: '2-digit',
     second: '2-digit',
     hour12: false,
-  }).format(new Date(timestamp));
+  }).format(new Date(timestamp * 1000));
 }


### PR DESCRIPTION
# Frontend date

## Bug Fixes

- *(frontend)* Date wasn't correct

debugged with the firefox JS console

```js
var d = new Date(1735056819);
undefined
console.log(d)
Date Wed Jan 21 1970 02:57:36 GMT+0100 (Central European Standard Time) debugger eval code:1:9
undefined
var d = new Date(1735056819000);
undefined
console.log(d)
Date Tue Dec 24 2024 17:13:39 GMT+0100 (Central European Standard Time)
```